### PR TITLE
Added support for Windows

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -201,9 +201,9 @@ Job.prototype = {
       if (ind !== -1) self.commands.splice(ind, 1)
       next(exitCode, std.out, std.err)
     })
-    proc.on('error', function(err) {
+    proc.on('error', function() {
       // prevent node from throwing an error
-    }) 
+    })
 
     var strCmd = shellQuote([cmd.command].concat(cmd.args))
       , display = cmd.screen || strCmd


### PR DESCRIPTION
The biggest issue in this module was that Windows uses a `;` to separate paths instead of `:`.
These changes should help with https://github.com/Strider-CD/strider/issues/326
