### PR TITLE
Emit job.status.phase.errored

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -303,6 +303,7 @@ Job.prototype = {
     if (err) {
       if (err.type === 'exitCode') code = err.code
       if ('number' === typeof err) code = err
+      this.status('phase.errored', { time: now, exitCode: code });
       if (code === 0) {
         this.error(err)
         return this.done(err, next)


### PR DESCRIPTION
There is no way for plugins to know that a phase has errored out.
Now plugins can listen for this event.

https://github.com/Strider-CD/strider-slack/commit/e39690411b9a5b5238d9ca8f27222343d89d562c depends on this
